### PR TITLE
feat: Add GitHub Actions workflow for deploying to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # Trigger deployment on pushes to the main branch
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8 # You can specify a pnpm version if needed
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build project
+        run: pnpm build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # This is a GUESS. Replace with the correct path to your site's build output.
+          path: ./apps/web/dist
+
+  # Deploy job
+  deploy:
+    needs: build-and-deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        # This will automatically use the artifact uploaded in the build-and-deploy job


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow that automates the deployment of the project to GitHub Pages.

The workflow is configured to:
- Trigger on pushes to the 'main' branch.
- Use pnpm for package management.
- Install dependencies using 'pnpm install --frozen-lockfile'.
- Build the project using 'pnpm build'.
- Upload the build artifact for GitHub Pages.
- Deploy the artifact to GitHub Pages.

The build output path in the 'upload-pages-artifact' step is currently set to './apps/web/dist'. This is a placeholder and MUST be verified and updated by you to match your Turborepo project's actual static site output directory.

The workflow uses 'actions/checkout@v4', 'pnpm/action-setup@v3', 'actions/configure-pages@v4', 'actions/upload-pages-artifact@v3', and 'actions/deploy-pages@v4'.